### PR TITLE
Add indent/dedent patterns

### DIFF
--- a/languages/fish/config.toml
+++ b/languages/fish/config.toml
@@ -16,3 +16,11 @@ brackets = [
         "string",
     ] },
 ]
+
+# Indent if the line starts with a keyword that must be followed by one or more parameters *or*
+# if the line starts and ends with `begin` or `else` *or*
+# if the line ends with an opening parentheses or a backslash.
+increase_indent_pattern = "^\\s*(function|if|else\\s+if|while|for|switch|case)\\b|^\\s*(begin|else)\\s*$|[(\\\\]\\s*$"
+
+# Dedent if the line starts with a keyword that ends a block or with a closing parentheses.
+decrease_indent_pattern = "^\\s*(else|case|end)\\b|^\\s*\\)"

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -65,3 +65,46 @@
 ; Note that an expression like `echo _&_` contains a background operator
 ; prior to fish 3.5 and that's how it's handled here.
 ((command) "&" @keyword)
+
+
+;; Work around two issues in the compiled grammar.
+
+; (1)
+; Issue: the leading file descriptor in a redirection is missing.
+; Expample: redirect stderr with 2> and the "2" won't get matched.
+; Workaround: within a command, locate the last integer node preceding the
+; redirect and mark that as @operator.
+(command
+    name: (concatenation _+ (integer) @operator .)
+    redirect: _)
+
+; (2)
+; Issue: commands are not split into the fields (name) (arguments) (comment).
+;
+; The whole expression is wrapped in the field (name) which in turn consists
+; either of one (word) or a (concatenation).
+;
+; The grammar doesn't mark trailing comments and we have to look for "#" and
+; assign all following nodes ourselves. Parentheses within trailing commands
+; are problematic as they start a command substitution and can't be matched
+; by the wildcard node. Sigh.
+;
+; Workaround: use four rules to do the splitting:
+; 1. capture commands with no arguments (word)
+; 2. capture commands with arguments (concatenation)
+; 3. capture command options (arguments starting with "-")
+; 4. capture trailing comments (can't catch everything)
+
+(command name: [
+    ((word) @function)
+    (concatenation . (word) @function)
+    (concatenation (word) @constant (#match? @constant "^-"))
+    (concatenation ("#" @comment _* @comment))
+])
+
+(function_definition name: [
+    ((word) @function)
+    (concatenation . (word) @function)
+    (concatenation (word) @constant (#match? @constant "^-"))
+    (concatenation ("#" @comment _* @comment))
+])

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -6,6 +6,10 @@
 [(integer) (float)] @number
 
 [
+  "not"
+  "!"
+  "and"
+  "or"
   "&&"
   "||"
   "|"
@@ -52,10 +56,6 @@
  "end"
  "while"
  "for"
- "not"
- "!"
- "and"
- "or"
  "return"
  (break)
  (continue)

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -14,7 +14,6 @@
   "||"
   "|"
   "&"
-  ".."
   (direction)
   (stream_redirect)
 ] @operator
@@ -29,11 +28,9 @@
   name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
   argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
 
-(variable_expansion) @constant
+[(variable_expansion) (list_element_access)] @constant
 
 [
- "["
- "]"
  "{"
  "}"
  "("

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -30,14 +30,12 @@
 
 [(variable_expansion) (list_element_access)] @constant
 
-[
- "{"
- "}"
- "("
- ")"
-] @punctuation.bracket
+(command_substitution ["$" "(" ")"]) @punctuation.bracket
 
-"," @punctuation.delimiter
+; Brace expansion and globbing.
+; Note: (glob) matches "*" but not "?". It's in the grammar and we can't
+; query it differently.
+["{" "}" "," (home_dir_expansion) (glob)] @operator
 
 (function_definition name: [(word) (concatenation)] @function)
 (command name: (word) @function)

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -37,21 +37,31 @@
 ; query it differently.
 ["{" "}" "," (home_dir_expansion) (glob)] @operator
 
-(function_definition name: [(word) (concatenation)] @function)
-(command name: (word) @function)
+; Conditionals
+(if_statement ["if" "end"] @keyword)
+(switch_statement ["switch" "end"] @keyword)
+(case_clause ["case"] @keyword)
+(else_clause ["else"] @keyword)
+(else_if_clause ["else" "if"] @keyword)
 
+; Loops/Blocks
+(while_statement ["while" "end"] @keyword)
+(for_statement ["for" "end"] @keyword)
+(begin_statement ["begin" "end"] @keyword)
+
+; Functions
+(function_definition ["function" "end"] @keyword)
+
+; Keywords
 [
- "switch"
- "case"
  "in"
- "begin"
- "function"
- "if"
- "else"
- "end"
- "while"
- "for"
+ ";"
  "return"
  (break)
  (continue)
 ] @keyword
+
+; Treat "&" as a background operator only if it's preceded by a command.
+; Note that an expression like `echo _&_` contains a background operator
+; prior to fish 3.5 and that's how it's handled here.
+((command) "&" @keyword)

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -108,3 +108,7 @@
     (concatenation (word) @constant (#match? @constant "^-"))
     (concatenation ("#" @comment _* @comment))
 ])
+
+
+;; Error
+(ERROR) @hint


### PR DESCRIPTION
Carrying over the discussion from [Zed Extensions #275](https://github.com/zed-industries/extensions/issues/275).

Indentation works well when typing the following code blocks:

```fish
function testing -d Blah
    begin
        begin
            ls
        end
    end
    
    if true
        echo
    else if true
        echo
    else
        ls
    end
    
    switch $argv[1]
    case a
        ls
    case b
        ls
    end
    
    for i in (seq 3)
        echo $i
    end
    
    while x
        ls
    end
end
``` 

The following examples can't be covered:

```fish
for i in (seq 3); echo $i; end
   # wrongly indents here 

echo "x x x" \
    "hi"
   # does not dedent here 
```

Generally, these patterns don't work when moving lines up and down with Ctrl-Cmd-Up/Down.

I think the patterns work well enough in the majority of cases. Good you put them in in the first place -- I hadn't seen them before.

Alternatively, tree-sitter has its own indentation system but I won't dive into that 😱.