### PR TITLE
Update for Zed 0.127.3

### DIFF
--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -33,7 +33,7 @@
 
 [(variable_expansion) (list_element_access)] @variable.special
 
-(command_substitution ["$" "(" ")"]) @punctuation.bracket
+(command_substitution ["$" "(" ")"]) @embedded
 
 ; Brace expansion and globbing.
 ; Note: (glob) matches "*" but not "?".

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -92,14 +92,14 @@
 (command name: [
     ((word) @function)
     (concatenation . (word) @function)
-    (concatenation (word) @primary (#match? @primary "^-."))
+    (concatenation (word) @constant (#match? @constant "^-."))
     (concatenation ("#" @comment _* @comment))
 ])
 
 (function_definition name: [
     ((word) @function)
     (concatenation . (word) @function)
-    (concatenation (word) @primary (#match? @primary "^-."))
+    (concatenation (word) @constant (#match? @constant "^-."))
     (concatenation ("#" @comment _* @comment))
 ])
 

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -14,19 +14,19 @@
   "||"
   "|"
   "&"
-  (direction)
+  (file_redirect)
   (stream_redirect)
 ] @operator
 
 ; match operators of test command
-(command
-  name: (word) @function (#match? @function "^test$")
-  argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+; (command
+;   name: (word) @function (#match? @function "^test$")
+;   argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
 
 ; match operators of [ command
-(command
-  name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
-  argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+; (command
+;   name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
+;   argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
 
 [(variable_expansion) (list_element_access)] @constant
 
@@ -46,20 +46,14 @@
 
 ; Loops/Blocks
 (while_statement ["while" "end"] @keyword)
-(for_statement ["for" "end"] @keyword)
+(for_statement ["for" "in" "end"] @keyword)
 (begin_statement ["begin" "end"] @keyword)
 
 ; Functions
 (function_definition ["function" "end"] @keyword)
 
 ; Keywords
-[
- "in"
- ";"
- "return"
- (break)
- (continue)
-] @keyword
+[";" (return) (break) (continue)] @keyword
 
 ; Treat "&" as a background operator only if it's preceded by a command.
 ; Note that an expression like `echo _&_` contains a background operator
@@ -98,14 +92,14 @@
 (command name: [
     ((word) @function)
     (concatenation . (word) @function)
-    (concatenation (word) @constant (#match? @constant "^-"))
+    (concatenation (word) @primary (#match? @primary "^-."))
     (concatenation ("#" @comment _* @comment))
 ])
 
 (function_definition name: [
     ((word) @function)
     (concatenation . (word) @function)
-    (concatenation (word) @constant (#match? @constant "^-"))
+    (concatenation (word) @primary (#match? @primary "^-."))
     (concatenation ("#" @comment _* @comment))
 ])
 

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -18,23 +18,25 @@
   (stream_redirect)
 ] @operator
 
+(command name: (word) @function)
+(command argument: (word) @constant (#match? @constant "^-."))
+
 ; match operators of test command
-; (command
-;   name: (word) @function (#match? @function "^test$")
-;   argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+(command
+  name: (word) @function (#match? @function "^test$")
+  argument: (word) @constant (#match? @constant "^(!?=|!)$"))
 
 ; match operators of [ command
-; (command
-;   name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
-;   argument: (word) @operator (#match? @operator "^(!?=|-[a-zA-Z]+)$"))
+(command
+  name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
+  argument: (word) @constant (#match? @constant "^(!?=|!)$"))
 
-[(variable_expansion) (list_element_access)] @constant
+[(variable_expansion) (list_element_access)] @variable.special
 
 (command_substitution ["$" "(" ")"]) @punctuation.bracket
 
 ; Brace expansion and globbing.
-; Note: (glob) matches "*" but not "?". It's in the grammar and we can't
-; query it differently.
+; Note: (glob) matches "*" but not "?".
 ["{" "}" "," (home_dir_expansion) (glob)] @operator
 
 ; Conditionals
@@ -54,55 +56,6 @@
 
 ; Keywords
 [";" (return) (break) (continue)] @keyword
-
-; Treat "&" as a background operator only if it's preceded by a command.
-; Note that an expression like `echo _&_` contains a background operator
-; prior to fish 3.5 and that's how it's handled here.
-((command) "&" @keyword)
-
-
-;; Work around two issues in the compiled grammar.
-
-; (1)
-; Issue: the leading file descriptor in a redirection is missing.
-; Expample: redirect stderr with 2> and the "2" won't get matched.
-; Workaround: within a command, locate the last integer node preceding the
-; redirect and mark that as @operator.
-(command
-    name: (concatenation _+ (integer) @operator .)
-    redirect: _)
-
-; (2)
-; Issue: commands are not split into the fields (name) (arguments) (comment).
-;
-; The whole expression is wrapped in the field (name) which in turn consists
-; either of one (word) or a (concatenation).
-;
-; The grammar doesn't mark trailing comments and we have to look for "#" and
-; assign all following nodes ourselves. Parentheses within trailing commands
-; are problematic as they start a command substitution and can't be matched
-; by the wildcard node. Sigh.
-;
-; Workaround: use four rules to do the splitting:
-; 1. capture commands with no arguments (word)
-; 2. capture commands with arguments (concatenation)
-; 3. capture command options (arguments starting with "-")
-; 4. capture trailing comments (can't catch everything)
-
-(command name: [
-    ((word) @function)
-    (concatenation . (word) @function)
-    (concatenation (word) @constant (#match? @constant "^-."))
-    (concatenation ("#" @comment _* @comment))
-])
-
-(function_definition name: [
-    ((word) @function)
-    (concatenation . (word) @function)
-    (concatenation (word) @constant (#match? @constant "^-."))
-    (concatenation ("#" @comment _* @comment))
-])
-
 
 ;; Error
 (ERROR) @hint


### PR DESCRIPTION
The tree-sitter code in the newest stable Zed version 0.127.3 has been updated and resolves some issues in the syntax tree and the fish grammar is parsed correctly. 

This PR removes the workarounds for the old issues in `highlights.scm` and thus makes the queries terse and much cleaner.

Also, I changed a few syntax tokens to match the ones of Zed's `bash` highlighting.