### PR TITLE
Update the tree-sitter-fish grammar to commit a78aef9

### DIFF
--- a/grammars/fish.toml
+++ b/grammars/fish.toml
@@ -1,2 +1,2 @@
 repository = "https://github.com/ram02z/tree-sitter-fish"
-commit = "f9176908c9eb2e11eb684d79e1d00f3b29bd65c9"
+commit = "a78aef9abc395c600c38a037ac779afc7e3cc9e0"

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -12,24 +12,27 @@
   "or"
   "&&"
   "||"
-  "|"
-  "&"
   (file_redirect)
   (stream_redirect)
 ] @operator
 
+; Operators that end a command
+(pipe ["|" "2>|" "&|"] @keyword)
+[";" "&"] @keyword
+
+; Commands
 (command name: (word) @function)
 (command argument: (word) @constant (#match? @constant "^-."))
 
 ; match operators of test command
 (command
-  name: (word) @function (#match? @function "^test$")
-  argument: (word) @constant (#match? @constant "^(!?=|!)$"))
+  name: (word) @function (#eq? @function "test")
+  argument: (word) @constant (#match? @constant "^(-[A-Za-z]+|!?=|!)$"))
 
 ; match operators of [ command
 (command
-  name: (word) @punctuation.bracket (#match? @punctuation.bracket "^\\[$")
-  argument: (word) @constant (#match? @constant "^(!?=|!)$"))
+  name: (word) @punctuation.bracket (#eq? @punctuation.bracket "[")
+  argument: (word) @constant (#match? @constant "^(-[A-Za-z]+|!?=|!)$"))
 
 [(variable_expansion) (list_element_access)] @variable.special
 
@@ -53,9 +56,10 @@
 
 ; Functions
 (function_definition ["function" "end"] @keyword)
+(function_definition option: (word) @constant (#match? @constant "^-."))
 
 ; Keywords
-[";" (return) (break) (continue)] @keyword
+[(return) (break) (continue)] @keyword
 
-;; Error
+; Errors
 (ERROR) @hint


### PR DESCRIPTION
This PR points `fish.toml` to the latest commit of the tree-sitter-fish grammar. Credits to the kind folks at [tree-sitter-fish](https://github.com/ram02z/tree-sitter-fish) for their support.

The updated grammar 
- parses all pipe operators including `&|` and `2>|` correctly 
- drops support for `^` in redirections (was removed in fish 3.5) 
- allows the caret `^` in bare words

Finally, the last few glitches in the syntax highlighting I'm aware of have been fixed.