### PR TITLE
Add highlighting for regex patterns

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "Fish",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "authors": [
     "Hasit Mistry <hasitnm@gmail.com>"
   ],

--- a/languages/fish/injections.scm
+++ b/languages/fish/injections.scm
@@ -1,0 +1,14 @@
+((command
+  name: (word) @_command
+  .
+  argument: (word) @_verb
+  argument: (single_quote_string) @content)
+  (#eq? @_command "string")
+  (#any-of? @_verb "match" "replace")
+  (#set! "language" "regex"))
+
+((command
+  name: (word) @_command
+  argument: (single_quote_string) @content)
+  (#any-of? @_command "grep" "egrep" "rg" "sed")
+  (#set! "language" "regex"))


### PR DESCRIPTION
This PR adds `injections.scm`. The queries look for the commands `string match`, `string replace`, `grep`, `egrep`, `rg`, `sed` and inject Zed's built-in regex language into single quoted strings. This makes regex patterns more legible (hopefully).

Some examples:

<img width="636" alt="Screen Shot 2024-04-25 at 12 11 41" src="https://github.com/hasit/zed-fish/assets/71228733/808ae939-27c0-4ca6-af07-9a8948c5e202">
