### PR TITLE
Add extension.toml

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,0 +1,17 @@
+name = "Fish"
+version = "0.0.9"
+authors = ["Hasit Mistry <hasitnm@gmail.com>"]
+description = "Fish language support for Zed"
+repository = "https://github.com/hasit/zed-fish"
+id = "fish"
+schema_version = 1
+
+[languages]
+Fish = "languages/fish"
+
+[grammars]
+fish = "grammars/fish.wasm"
+grammar = "fish"
+[grammars.fish]
+repository = "https://github.com/ram02z/tree-sitter-fish"
+commit = "a78aef9abc395c600c38a037ac779afc7e3cc9e0"


### PR DESCRIPTION
This PR adds 'extension.toml' file, converting from the existing 'extension.json' configuration.
See https://github.com/zed-industries/extensions/issues/2104

This change was generated automatically and needs to be manually tested.
Bot script: https://github.com/sigmaSd/botfixzed/blob/master/bot.ts