### PR TITLE
Add fish_indent as external formatter

### DIFF
--- a/languages/fish/config.toml
+++ b/languages/fish/config.toml
@@ -24,3 +24,6 @@ increase_indent_pattern = "^\\s*(function|if|else\\s+if|while|for|switch|case)\\
 
 # Dedent if the line starts with a keyword that ends a block or with a closing parentheses.
 decrease_indent_pattern = "^\\s*(else|case|end)\\b|^\\s*\\)"
+
+[formatter]
+external = { command = "fish_indent", arguments = [] }


### PR DESCRIPTION
Adds support for using `fish_indent` formatter in fish scripts

https://fishshell.com/docs/current/cmds/fish_indent.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fish shell code formatter support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->