### PR TITLE
Fix some highlighting issues and add syntax test cases

### DIFF
--- a/languages/fish/brackets.scm
+++ b/languages/fish/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -23,6 +23,7 @@
 ; Commands
 (command name: (word) @function)
 (command argument: (word) @constant (#match? @constant "^-."))
+(command argument: (concatenation . (word) @constant (#match? @constant "^-.")))
 
 ; match operators of test command
 (command
@@ -57,6 +58,7 @@
 ; Functions
 (function_definition ["function" "end"] @keyword)
 (function_definition option: (word) @constant (#match? @constant "^-."))
+(function_definition option: (concatenation . (word) @constant (#match? @constant "^-.")))
 
 ; Keywords
 [(return) (break) (continue)] @keyword

--- a/languages/fish/highlights.scm
+++ b/languages/fish/highlights.scm
@@ -1,3 +1,8 @@
+; Explicitly use the primary editor foreground color for words.
+; This is required for words (e.g., a file path) inside command substitutions
+; that are wrapped in double-quoted strings.
+(word) @primary
+
 [(double_quote_string) (single_quote_string)] @string
 (escape_sequence) @string.escape
 
@@ -37,7 +42,7 @@
 
 [(variable_expansion) (list_element_access)] @variable.special
 
-(command_substitution ["$" "(" ")"]) @embedded
+(command_substitution "$" @punctuation.special)
 
 ; Brace expansion and globbing.
 ; Note: (glob) matches "*" but not "?".

--- a/syntax-test-cases/test-cases.fish
+++ b/syntax-test-cases/test-cases.fish
@@ -1,0 +1,33 @@
+# Add compound commands introduced in fish 4.1.
+# `begin; echo 1; echo 2; end` can now be written using braces, like in other shells.
+# (added in tree-sitter-fish v3.7.0)
+true && { echo 1; echo 2 }
+
+# Fix the highlighting of options.
+foo -f --flag --aa=12 --bb 12 --cc=text plain_text_argument
+foo --single-quotes='blah'
+foo --double-quotes="blah"
+foo --firewall={fw1,fw2}
+foo --ssh-keys=(path resolve ~/.ssh/id_*.pub)
+cut -d" " -f2
+cut -d' ' -f2
+cut -d\  -f2
+
+function foo --description='Blah'
+    true
+end
+
+# Change the capture for command_substitution from `@embedded` to `@punctuation.special`
+# which is common in other languages supported by Zed.
+# This screenshot was taken with Zed's "Colorize Brackets" feature enabled.
+echo "$(ls $(pwd)) $bar"
+
+# Fix plain words like file paths being falsely highlighted in command substitutions
+# that are wrapped in double-quoted strings.
+echo "$(ls ~/mydirectory)"
+
+# Fix opening parentheses being misinterpreted as command substitution in double-quoted strings.
+# (fixed in tree-sitter-fish f435b0bd, the following lines don't cause errors anymore)
+foo "()"
+foo "("
+foo ")"


### PR DESCRIPTION
This requires the new tree-sitter-fish grammar from PR "Bump upstream grammar #16".

- Highlight matching parentheses/brackets/curlies.
- Fix highlighting of options.
- Fix highlighting of command substitutions.
- Add test-cases.fish to visually check the highlighting in Zed. With this PR merged, it will look like:

<img width="854" height="799" alt="Screenshot 2026-04-17 at 00 19 30" src="https://github.com/user-attachments/assets/8bb1c284-6787-43af-8c08-ff114398129e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bracket-pair detection for parentheses, square brackets, and curly braces.
  * Enhanced syntax highlighting for command options and arguments.
  * Improved highlighting for words within command substitutions.
  * Better support for compound commands using braces.

* **Tests**
  * Added comprehensive test coverage for bracket usage, option highlighting, and quoted string handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->